### PR TITLE
Cloudflare: Adding dalexeenko as the DRI to bother for billing

### DIFF
--- a/src/data/companies/cloudflare.json
+++ b/src/data/companies/cloudflare.json
@@ -59,6 +59,12 @@
       "contacts": [
         { "product": "Durable Objects", "handles": ["@cmdhaus"] }
       ]
+    },
+    {
+      "name": "Billing & Payments",
+      "contacts": [
+        { "product": "Billing, Payments, Subscriptions, Invoices", "handles": ["@dalexeenko"] }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Cloudflare: Adding dalexeenko as the DRI to bother for everything related to billing and payments at Cloudflare.