### PR TITLE
Durable Objects @ Cloudflare

### DIFF
--- a/src/data/companies/cloudflare.json
+++ b/src/data/companies/cloudflare.json
@@ -25,6 +25,7 @@
       "name": "Compute & AI",
       "contacts": [
         { "product": "Workers Platform", "handles": ["@KentonVarda", "@yagiznizipli"] },
+        { "product": "Durable Objects", "handles": ["@KentonVarda", "@ajoshhoward"] },
         { "product": "AI Search (fka. AutoRAG)", "handles": ["@aninibread", "@G4brym"] },
         { "product": "AI Agents & MCP", "handles": ["@threepointone", "@whoiskatrin", "@mattzcarey"] },
         { "product": "AI Gateway", "handles": ["@KankaniAbhishek","@_mchenco"]},
@@ -52,12 +53,6 @@
       "contacts": [
         { "product": "Manager of Developer Advocacy", "handles": ["@kristianf_"] },
         { "product": "Developer Advocate", "handles": ["@lauragift_"] }
-      ]
-    },
-    {
-      "name": "Developer Community",
-      "contacts": [
-        { "product": "Durable Objects", "handles": ["@cmdhaus"] }
       ]
     }
   ]


### PR DESCRIPTION
The Cloudflare page listed [cmdhaus](https://x.com/cmdhaus) as the person to bother for Durable Objects, but he is not a Cloudflare employee. Maybe "Developer Community" was supposed to imply "these are people in the community, not employees", but I think that isn't clear enough and most people would expect that everyone on the page is an employee.

So, I removed that entry and added a replacement reference for Durable Objects.

(No offense to cmdhaus, he definitely is a Cloudflare power user working on cool stuff at Zero Email!)

Note I put Durable Object under "Compute" rather than "Storage" because this is how we think of it internally. Although DO does come with storage, it is best understood as a compute product and a feature of Cloudflare Workers.