### PR TITLE
docs: add Cloudflare DevRel handle verification log (2026-04)

### DIFF
--- a/CHANGELOG.devrel.md
+++ b/CHANGELOG.devrel.md
@@ -1,0 +1,33 @@
+# Cloudflare DevRel Handle Verification Log
+
+## 2026-04-12
+
+### Verified Handles
+
+**Managers of Developer Advocacy:**
+- `@kristianf_` - Confirmed correct (updated from legacy `@kristianfreeman`)
+- `@ade_oshineye` - Confirmed correct
+
+**Developer Advocates:**
+- `@craigsdennis` - Confirmed correct
+- `@Jilles` - Confirmed correct
+- `@megaconfidence` - Confirmed correct
+- `@harshil1712` - Confirmed correct
+- `@lauragift_` - Confirmed correct
+- `@fayazara` - Confirmed correct
+- `@yusukebe` - Confirmed correct
+
+### Changes Documented
+- Handle verification against official source: `kulterryan/who-to-bother-at-on-x/src/data/companies/cloudflare.json`
+- No handle changes detected in this verification cycle
+- All handles match the official data source as of 2026-04-12
+
+### Notes
+- Previous handle `@kristianfreeman` has been updated to `@kristianf_` (same person)
+- All Developer Advocates have underscores in their handles except `@Jilles`, `@craigsdennis`, `@harshil1712`, and `@yusukebe`
+- Team structure remains stable with 2 Managers and 7 Developer Advocates
+
+### Verification Method
+- Fetched raw JSON from GitHub: `https://raw.githubusercontent.com/kulterryan/who-to-bother-at-on-x/main/src/data/companies/cloudflare.json`
+- Cross-referenced with local memory and skill files
+- Confirmed all handles are current and accurate


### PR DESCRIPTION
Verified and documented Cloudflare DevRel Twitter handles as of 2026-04-12.

## Handle Verification
- **Managers:** @kristianf_ and @ade_oshineye (confirmed correct)
- **Developer Advocates:** @craigsdennis, @Jilles, @megaconfidence, @harshil1712, @lauragift_, @fayazara, @yusukebe (all confirmed)

## Notes
- Handle @kristianfreeman has been updated to @kristianf_ (same person)
- All handles match the official data source
- No handle changes detected in this verification cycle

## Source
- Official: kulterryan/who-to-bother-at-on-x/src/data/companies/cloudflare.json
- Verification date: 2026-04-12